### PR TITLE
Reorder TranscriptForm elements - place file upload at top

### DIFF
--- a/src/TranscriptForm/index.js
+++ b/src/TranscriptForm/index.js
@@ -53,6 +53,22 @@ const TranscriptForm = ({ ...props }) => {
   return (
     <>
       <Form noValidate validated={ isValidated } onSubmit={ e => handleSubmit(e) }>
+        <Form.Group controlId="formTranscriptMediaFile">
+          <Form.Control
+            required
+            type="file"
+            label="Upload"
+            accept="audio/*,video/*"
+            onChange={ e => handleFileUpload(e) }
+          />
+          <Form.Text className="text-muted">
+            Select an audio or video file to upload
+          </Form.Text>
+          <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
+          <Form.Control.Feedback type="invalid">
+            Please choose a audio or video file to upload
+          </Form.Control.Feedback>
+        </Form.Group>
         <Form.Group controlId="formTranscriptTitle">
           <Form.Label>Title</Form.Label>
           <Form.Control
@@ -85,22 +101,6 @@ const TranscriptForm = ({ ...props }) => {
           <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
           <Form.Control.Feedback type="invalid">
             Please choose a description for your transcript
-          </Form.Control.Feedback>
-        </Form.Group>
-        <Form.Group controlId="formTranscriptMediaFile">
-          <Form.Control
-            required
-            type="file"
-            label="Upload"
-            accept="audio/*,video/*"
-            onChange={ e => handleFileUpload(e) }
-          />
-          <Form.Text className="text-muted">
-            Select an audio or video file to upload
-          </Form.Text>
-          <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
-          <Form.Control.Feedback type="invalid">
-            Please choose a audio or video file to upload
           </Form.Control.Feedback>
         </Form.Group>
         <Modal.Footer>


### PR DESCRIPTION
Tiny PR - reorder elements in New Transcript form so that the file selector is at the top - that way the title gets auto-filled, still allowing the user to edit it. Currently there's no indication this field would be automatically filled out if left blank, and makes the user have to think of a title before they start the upload.

![Screenshot 2020-04-17 at 17 12 43](https://user-images.githubusercontent.com/1609725/79593117-e283d700-80d2-11ea-92ad-54887b9698db.png)