### PR TITLE
Remove deletion prompt and refactor delete function

### DIFF
--- a/src/TranscriptCard/index.js
+++ b/src/TranscriptCard/index.js
@@ -21,17 +21,12 @@ import {
 const TranscriptCard = props => {
 
   const handleDelete = () => {
-    const confirmDeleteText = 'Are you sure you want to delete?';
-    const cancelDeleteText = 'Cancelled delete';
+    const confirmed = confirm('Are you sure you want to delete?');
 
-    const confirmationPrompt = confirm(confirmDeleteText);
-
-    if (confirmationPrompt) {
+    if (confirmed) {
       if (props.handleDeleteItem) {
         props.handleDeleteItem(props.id);
       }
-    } else {
-      alert(cancelDeleteText);
     }
   };
 


### PR DESCRIPTION
Tiny PR, removes the extraneous confirmation of deletion prompt after deleting a transcript.

I also tidied up by removing the (I think) unnecessary variables for the messages, and renamed the variable used for the confirmation dialogue.

No linked issue.