### PR TITLE
[feat]: Adds double click handling to PreviewCanvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/digital-paper-edit-storybook",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/PreviewCanvas/VideoContextPreview/index.js
+++ b/src/PreviewCanvas/VideoContextPreview/index.js
@@ -36,6 +36,18 @@ const VideoContextPreview = (props) => {
     }
   }, [ props.canvasRef ]);
 
+  useEffect(() => {
+    if (props.currentTime) {
+
+      setVideoContext(vc => {
+        vc.currentTime = props.currentTime;
+        videoContext.play();
+
+        return vc;
+      });
+    }
+  }, [ props.currentTime, videoContext ]);
+
   if (videoContext) {
     updateVideoContext(props.playlist);
   }
@@ -76,7 +88,8 @@ VideoContextPreview.propTypes = {
   canvasRef: PropTypes.any,
   playlist: PropTypes.array,
   videoContext: PropTypes.any,
-  width: PropTypes.any
+  width: PropTypes.any,
+  currentTime: PropTypes.any
 };
 
 VideoContextPreview.defaultProps = {

--- a/src/PreviewCanvas/index.js
+++ b/src/PreviewCanvas/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useRef } from 'react';
-import VideoContextPreview from '@bbc/digital-paper-edit-storybook/PreviewCanvas';
+import VideoContextPreview from './VideoContextPreview';
 import PropTypes from 'prop-types';
 
 const PreviewCanvas = props => {

--- a/src/PreviewCanvas/index.js
+++ b/src/PreviewCanvas/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 
 const PreviewCanvas = props => {
   const canvasRef = useRef();
+  console.log('Inside PreviewCanvas');
 
   return (
     <VideoContextPreview

--- a/src/PreviewCanvas/index.js
+++ b/src/PreviewCanvas/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useRef } from 'react';
-import VideoContextPreview from './VideoContextPreview';
+import VideoContextPreview from '@bbc/digital-paper-edit-storybook/PreviewCanvas';
 import PropTypes from 'prop-types';
 
 const PreviewCanvas = props => {

--- a/src/PreviewCanvas/index.js
+++ b/src/PreviewCanvas/index.js
@@ -11,6 +11,7 @@ const PreviewCanvas = props => {
       width={ props.width }
       canvasRef={ canvasRef }
       playlist={ props.playlist }
+      currentTime={ props.currentTime }
     />
   );
 };

--- a/src/ProgrammeScriptContainer/index.js
+++ b/src/ProgrammeScriptContainer/index.js
@@ -49,7 +49,6 @@ const ProgrammeScriptContainer = (props) => {
       </article>
     </Card>
   );
-
 };
 
 ProgrammeScriptContainer.propTypes = {

--- a/src/ProgrammeScriptContainer/index.js
+++ b/src/ProgrammeScriptContainer/index.js
@@ -9,8 +9,12 @@ import PreviewCanvas from '../PreviewCanvas';
 const ProgrammeScriptContainer = (props) => {
   const [ items, setItems ] = useState(props.items);
   const [ timeOnClick, setTimeOnClick ] = useState();
-  const width = props.width;
-  const playlist = props.playlist;
+  const width = useState(150);
+  const playlist = [
+    { type: 'video', start: 0, sourceStart: 30, duration: 10, src: 'https://download.ted.com/talks/MorganVague_2018X.mp4' },
+    { type: 'video', start: 10, sourceStart: 40, duration: 10, src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4' },
+    { type: 'video', start: 20, sourceStart: 50, duration: 10, src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4' },
+  ];
 
   const previewCardRef = useRef();
 
@@ -23,7 +27,6 @@ const ProgrammeScriptContainer = (props) => {
   const handleDoubleClickOnProgrammeScript = (e) => {
     if (e.target.className === 'words') {
       const wordCurrentTime = e.target.dataset.start;
-      console.log('wordCurrentTime::', wordCurrentTime);
       setTimeOnClick(wordCurrentTime);
     }
   };
@@ -58,8 +61,6 @@ ProgrammeScriptContainer.propTypes = {
   handleDelete: PropTypes.func,
   handleEdit: PropTypes.func,
   handleReorder: PropTypes.func,
-  width: PropTypes.number,
-  playlist: PropTypes.array
 };
 
 export default ProgrammeScriptContainer;

--- a/src/ProgrammeScriptContainer/index.js
+++ b/src/ProgrammeScriptContainer/index.js
@@ -27,7 +27,6 @@ const ProgrammeScriptContainer = (props) => {
   const handleDoubleClickOnProgrammeScript = (e) => {
     if (e.target.className === 'words') {
       const wordCurrentTime = e.target.dataset.start;
-      console.log('currentTime: : ', wordCurrentTime);
       setTimeOnClick(wordCurrentTime);
     }
   };

--- a/src/ProgrammeScriptContainer/index.js
+++ b/src/ProgrammeScriptContainer/index.js
@@ -1,16 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import Card from 'react-bootstrap/Card';
 import arrayMove from 'array-move';
 import { SortableContainer, } from 'react-sortable-hoc';
 import ProgrammeElements from './ProgrammeElements';
+import PreviewCanvas from '../PreviewCanvas';
 
 const ProgrammeScriptContainer = (props) => {
   const [ items, setItems ] = useState(props.items);
+  const [ timeOnClick, setTimeOnClick ] = useState();
+  const width = props.width;
+  const playlist = props.playlist;
+
+  const previewCardRef = useRef();
 
   const onSortEnd = ({ oldIndex, newIndex }) => {
     const result = arrayMove(items, oldIndex, newIndex);
     props.handleReorder(result);
     setItems(result);
+  };
+
+  const handleDoubleClickOnProgrammeScript = (e) => {
+    if (e.target.className === 'words') {
+      const wordCurrentTime = e.target.dataset.start;
+      console.log('wordCurrentTime::', wordCurrentTime);
+      setTimeOnClick(wordCurrentTime);
+    }
   };
 
   const SortableList = SortableContainer(({ children }) =>
@@ -22,9 +37,18 @@ const ProgrammeScriptContainer = (props) => {
   const elements = ProgrammeElements(items, props.handleEdit, props.handleDelete);
 
   return (
-    <SortableList useDragHandle onSortEnd={ onSortEnd }>
-      {elements}
-    </SortableList>
+    <Card>
+      <Card.Header ref={ previewCardRef }>
+        <PreviewCanvas width={ width } playlist={ playlist } currentTime={ timeOnClick }/>
+      </Card.Header>
+      <article
+        onDoubleClick={ handleDoubleClickOnProgrammeScript }
+      >
+        <SortableList useDragHandle onSortEnd={ onSortEnd }>
+          {elements}
+        </SortableList>
+      </article>
+    </Card>
   );
 
 };
@@ -33,7 +57,9 @@ ProgrammeScriptContainer.propTypes = {
   items: PropTypes.any,
   handleDelete: PropTypes.func,
   handleEdit: PropTypes.func,
-  handleReorder: PropTypes.func
+  handleReorder: PropTypes.func,
+  width: PropTypes.number,
+  playlist: PropTypes.array
 };
 
 export default ProgrammeScriptContainer;

--- a/src/ProgrammeScriptContainer/index.js
+++ b/src/ProgrammeScriptContainer/index.js
@@ -10,11 +10,7 @@ const ProgrammeScriptContainer = (props) => {
   const [ items, setItems ] = useState(props.items);
   const [ timeOnClick, setTimeOnClick ] = useState();
   const width = useState(300);
-  const playlist = [
-    { type: 'video', start: 0, sourceStart: 30, duration: 10, src: 'https://download.ted.com/talks/MorganVague_2018X.mp4' },
-    { type: 'video', start: 10, sourceStart: 40, duration: 10, src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4' },
-    { type: 'video', start: 20, sourceStart: 50, duration: 10, src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4' },
-  ];
+  const playlist = props.playlist;
 
   const previewCardRef = useRef();
 
@@ -57,10 +53,11 @@ const ProgrammeScriptContainer = (props) => {
 };
 
 ProgrammeScriptContainer.propTypes = {
-  items: PropTypes.any,
   handleDelete: PropTypes.func,
   handleEdit: PropTypes.func,
   handleReorder: PropTypes.func,
+  items: PropTypes.any,
+  playlist: PropTypes.any
 };
 
 export default ProgrammeScriptContainer;

--- a/src/ProgrammeScriptContainer/stories/index.stories.js
+++ b/src/ProgrammeScriptContainer/stories/index.stories.js
@@ -10,10 +10,16 @@ export const handleDeleteActions = action('Handle delete');
 export const handleEditActions = action('Handle edit');
 
 const items = programmeScript;
+const playlist = [
+  { type: 'video', start: 0, sourceStart: 30, duration: 10, src: 'https://download.ted.com/talks/MorganVague_2018X.mp4' },
+  { type: 'video', start: 10, sourceStart: 40, duration: 10, src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4' },
+  { type: 'video', start: 20, sourceStart: 50, duration: 10, src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4' },
+];
 
 storiesOf('ProgrammeScript', module).add('Default', () => (
   <ProgrammeScriptContainer
     items={ items }
+    playlist={ playlist }
     handleDelete={ handleDeleteActions }
     handleEdit={ handleEditActions }
     handleReorder={ handleReorderActions }

--- a/src/ProgrammeScriptContainer/stories/index.stories.js
+++ b/src/ProgrammeScriptContainer/stories/index.stories.js
@@ -11,19 +11,11 @@ export const handleEditActions = action('Handle edit');
 
 const items = programmeScript;
 
-const playlist = [
-  { type: 'video', start: 0, sourceStart: 30, duration: 10, src: 'https://download.ted.com/talks/MorganVague_2018X.mp4' },
-  { type: 'video', start: 10, sourceStart: 40, duration: 10, src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4' },
-  { type: 'video', start: 20, sourceStart: 50, duration: 10, src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4' },
-];
-
 storiesOf('ProgrammeScript', module).add('Default', () => (
   <ProgrammeScriptContainer
     items={ items }
     handleDelete={ handleDeleteActions }
     handleEdit={ handleEditActions }
     handleReorder={ handleReorderActions }
-    width={ 300 }
-    playlist={ playlist }
   />
 ));

--- a/src/ProgrammeScriptContainer/stories/index.stories.js
+++ b/src/ProgrammeScriptContainer/stories/index.stories.js
@@ -11,11 +11,19 @@ export const handleEditActions = action('Handle edit');
 
 const items = programmeScript;
 
+const playlist = [
+  { type: 'video', start: 0, sourceStart: 30, duration: 10, src: 'https://download.ted.com/talks/MorganVague_2018X.mp4' },
+  { type: 'video', start: 10, sourceStart: 40, duration: 10, src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4' },
+  { type: 'video', start: 20, sourceStart: 50, duration: 10, src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4' },
+];
+
 storiesOf('ProgrammeScript', module).add('Default', () => (
   <ProgrammeScriptContainer
     items={ items }
     handleDelete={ handleDeleteActions }
     handleEdit={ handleEditActions }
     handleReorder={ handleReorderActions }
+    width={ 300 }
+    playlist={ playlist }
   />
 ));

--- a/src/ProgrammeScriptEditor/index.js
+++ b/src/ProgrammeScriptEditor/index.js
@@ -8,6 +8,7 @@ import ProgrammeScriptContainer from '../ProgrammeScriptContainer';
 import PreviewCanvas from '../PreviewCanvas';
 
 const ProgrammeScriptEditor = (props) => {
+  console.log('PSE props : : ', props);
   const Heading = (
     <h2
       title={ `Programme Script Title: ${ props.title }` }>
@@ -17,7 +18,7 @@ const ProgrammeScriptEditor = (props) => {
   const ProgrammeCard = (
     <Card>
       <Card.Header>
-        <PreviewCanvas width={ 300 } playlist={ props.playlist } />
+        <PreviewCanvas width={ 300 } playlist={ props.playlist } current={ props.currentTime }/>
       </Card.Header>
 
       <Card.Body>
@@ -60,7 +61,8 @@ ProgrammeScriptEditor.propTypes = {
   handleReorder: PropTypes.any,
   items: PropTypes.any,
   playlist: PropTypes.any,
-  title: PropTypes.any
+  title: PropTypes.any,
+  currentTime: PropTypes.any
 };
 
 export default ProgrammeScriptEditor;

--- a/src/ProgrammeScriptEditor/index.js
+++ b/src/ProgrammeScriptEditor/index.js
@@ -8,7 +8,6 @@ import ProgrammeScriptContainer from '../ProgrammeScriptContainer';
 import PreviewCanvas from '../PreviewCanvas';
 
 const ProgrammeScriptEditor = (props) => {
-  console.log('PSE props : : ', props);
   const Heading = (
     <h2
       title={ `Programme Script Title: ${ props.title }` }>

--- a/src/ProgrammeScriptEditor/index.js
+++ b/src/ProgrammeScriptEditor/index.js
@@ -17,10 +17,11 @@ const ProgrammeScriptEditor = (props) => {
   const ProgrammeCard = (
     <Card>
       <article
-        style={ { height: '60vh', overflow: 'scroll' } }
+        style={ { height: '100%', overflow: 'scroll' } }
       >
         <ProgrammeScriptContainer
           items={ props.items }
+          playlist={ props.playlist }
           handleReorder={ props.handleReorder }
           handleDelete={ props.handleDelete }
           handleEdit={ props.handleEdit }

--- a/src/ProgrammeScriptEditor/index.js
+++ b/src/ProgrammeScriptEditor/index.js
@@ -16,23 +16,17 @@ const ProgrammeScriptEditor = (props) => {
 
   const ProgrammeCard = (
     <Card>
-      <Card.Header>
-        <PreviewCanvas width={ 300 } playlist={ props.playlist } current={ props.currentTime }/>
-      </Card.Header>
+      <article
+        style={ { height: '60vh', overflow: 'scroll' } }
+      >
+        <ProgrammeScriptContainer
+          items={ props.items }
+          handleReorder={ props.handleReorder }
+          handleDelete={ props.handleDelete }
+          handleEdit={ props.handleEdit }
+        />
 
-      <Card.Body>
-        <article
-          style={ { height: '60vh', overflow: 'scroll' } }
-        >
-          <ProgrammeScriptContainer
-            items={ props.items }
-            handleReorder={ props.handleReorder }
-            handleDelete={ props.handleDelete }
-            handleEdit={ props.handleEdit }
-          />
-
-        </article>
-      </Card.Body>
+      </article>
     </Card>
   );
 

--- a/src/ProgrammeScriptEditor/stories/index.stories.js
+++ b/src/ProgrammeScriptEditor/stories/index.stories.js
@@ -9,8 +9,6 @@ export const handleDeleteActions = action('Handle delete');
 export const handleEditActions = action('Handle edit');
 export const handleDoubleClickActions = action('Handle double-click');
 
-const items = programmeScript;
-
 const playlist = [
   {
     type: 'video',
@@ -18,20 +16,6 @@ const playlist = [
     sourceStart: 30,
     duration: 10,
     src: 'https://download.ted.com/talks/MorganVague_2018X.mp4'
-  },
-  {
-    type: 'video',
-    start: 10,
-    sourceStart: 40,
-    duration: 10,
-    src: 'https://download.ted.com/talks/IvanPoupyrev_2019.mp4'
-  },
-  {
-    type: 'video',
-    start: 20,
-    sourceStart: 50,
-    duration: 10,
-    src: 'https://download.ted.com/talks/KateDarling_2018S-950k.mp4'
   }
 ];
 
@@ -41,7 +25,7 @@ storiesOf('ProgrammeScriptEditor (not published)', module).add(
     <ProgrammeScriptEditor
       title={ 'title' }
       playlist={ playlist }
-      items={ items }
+      items={ programmeScript }
       handleDelete={ handleDeleteActions }
       handleEdit={ handleEditActions }
       handleReorder={ handleReorderActions }

--- a/src/ProgrammeScriptEditor/stories/index.stories.js
+++ b/src/ProgrammeScriptEditor/stories/index.stories.js
@@ -7,6 +7,7 @@ import { programmeScript } from '../../dummy';
 export const handleReorderActions = action('Handle reorder');
 export const handleDeleteActions = action('Handle delete');
 export const handleEditActions = action('Handle edit');
+export const handleDoubleClickActions = action('Handle double-click');
 
 const items = programmeScript;
 
@@ -44,6 +45,7 @@ storiesOf('ProgrammeScriptEditor (not published)', module).add(
       handleDelete={ handleDeleteActions }
       handleEdit={ handleEditActions }
       handleReorder={ handleReorderActions }
+      handleDoubleClick={ handleDoubleClickActions }
     />
   )
 );

--- a/src/TranscriptCard/index.js
+++ b/src/TranscriptCard/index.js
@@ -21,17 +21,12 @@ import {
 const TranscriptCard = props => {
 
   const handleDelete = () => {
-    const confirmDeleteText = 'Are you sure you want to delete?';
-    const cancelDeleteText = 'Cancelled delete';
+    const confirmed = confirm('Are you sure you want to delete?');
 
-    const confirmationPrompt = confirm(confirmDeleteText);
-
-    if (confirmationPrompt) {
+    if (confirmed) {
       if (props.handleDeleteItem) {
         props.handleDeleteItem(props.id);
       }
-    } else {
-      alert(cancelDeleteText);
     }
   };
 

--- a/src/TranscriptCard/index.js
+++ b/src/TranscriptCard/index.js
@@ -208,7 +208,7 @@ const TranscriptCard = props => {
             <Col xs={ 12 }>
               <Alert variant={ 'info' }>
                 <FontAwesomeIcon icon={ faExclamationTriangle } />  Do not move away from or refresh this page until upload is complete!
-                <ProgressBar progress={ props.progress } />
+                {typeof(props.progress) === 'number' ? <ProgressBar progress={ props.progress } /> : null}
               </Alert>
               <Badge variant={ 'info' }>In progress</Badge>
             </Col>

--- a/src/dummy.js
+++ b/src/dummy.js
@@ -138,12 +138,48 @@ const programmeScript = [
   {
     type: 'paper-cut',
     id: 2,
+    start: 0.0,
+    end: 3.8,
     speaker: 'Mrs Loud',
     words: [
       {
-        text: 'Greatest day of my life was when I spoke this text.',
-        start: 0,
-        end: 1
+        speaker: 'TBC',
+        text: 'Saddle ',
+        start: 0.7,
+        end: 1.24,
+      },
+      {
+        speaker: 'TBC',
+        text: 'with ',
+        start: 1.24,
+        end: 1.55,
+      }, {
+        speaker: 'TBC',
+        text: 'has ',
+        start: 1.55,
+        end: 1.75
+      }, {
+        speaker: 'TBC',
+        text: 'a ',
+        start: 1.75,
+        end: 1.82,
+      }, {
+        text: 'stark ',
+        start: 1.82,
+        end: 2.47,
+        type: 'word',
+        speaker: 'TBC',
+      }, {
+        text: 'beauty',
+        start: 2.48,
+        end: 3.07,
+        speaker: 'TBC',
+      }, {
+        text: '.',
+        start: null,
+        end: null,
+        speaker: 'TBC',
+        type: 'punct'
       }
     ]
   },

--- a/src/dummy.js
+++ b/src/dummy.js
@@ -121,9 +121,73 @@ const programmeScript = [
     speaker: 'Mr Loud',
     words: [
       {
-        text: 'Greatest day of my life was when I wrote this text.',
+        text: 'Despite ',
         start: 0,
-        end: 1
+        end: 0.529
+      },
+      {
+        text: 'our ',
+        start: 0.529,
+        end: 0.679
+      },
+      {
+        text: 'best ',
+        start: 0.679,
+        end: 1.089
+      }, {
+        text: 'efforts ',
+        start: 1.089,
+        end: 1.829
+      }, {
+        text: 'only ',
+        start: 1.829,
+        end: 2.279
+      },
+      {
+        text: '9% ',
+        start: 2.279,
+        end: 3.419
+      },
+      {
+        text: 'of ',
+        start: 3.429,
+        end: 3.599
+      }, {
+        text: 'all ',
+        start: 3.609,
+        end: 3.949
+      }, {
+        text: 'plastic ',
+        start: 3.949,
+        end: 4.48
+      },
+      {
+        text: 'we ',
+        start: 4.48,
+        end: 4.709
+      },
+      {
+        text: 'use ',
+        start: 4.8,
+        end: 5.279
+      }, {
+        text: 'winds ',
+        start: 5.289,
+        end: 5.91
+      }, {
+        text: 'up ',
+        start: 5.91,
+        end: 6.109
+      },
+      {
+        text: 'being ',
+        start: 6.12,
+        end: 6.37
+      },
+      {
+        text: 'recycled. ',
+        start: 6.37,
+        end: 7.34
       }
     ]
   },
@@ -144,43 +208,32 @@ const programmeScript = [
     words: [
       {
         speaker: 'TBC',
-        text: 'Saddle ',
-        start: 0.7,
-        end: 1.24,
+        text: 'And ',
+        start: 8.45,
+        end: 8.65,
       },
       {
         speaker: 'TBC',
-        text: 'with ',
-        start: 1.24,
-        end: 1.55,
+        text: 'even ',
+        start: 8.65,
+        end: 8.96,
       }, {
         speaker: 'TBC',
-        text: 'has ',
-        start: 1.55,
-        end: 1.75
+        text: 'worse ',
+        start: 8.96,
+        end: 9.7
       }, {
         speaker: 'TBC',
-        text: 'a ',
-        start: 1.75,
-        end: 1.82,
+        text: 'plastic ',
+        start: 9.7,
+        end: 10.2,
       }, {
-        text: 'stark ',
-        start: 1.82,
-        end: 2.47,
+        text: 'is ',
+        start: 10.2,
+        end: 10.3,
         type: 'word',
         speaker: 'TBC',
-      }, {
-        text: 'beauty',
-        start: 2.48,
-        end: 3.07,
-        speaker: 'TBC',
-      }, {
-        text: '.',
-        start: null,
-        end: null,
-        speaker: 'TBC',
-        type: 'punct'
-      }
+      },
     ]
   },
   {


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/digital-paper-edit-storybook/issues) in this repository ?**      
Related to [issue #85 in DPE](https://github.com/bbc/digital-paper-edit-client/issues/85).

<!-- _If so please link to other issues and PRs as appropriate_ -->

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
- [x] Adds a prop for `currentTime` that can be passed to PreviewCanvas when a user double clicks on a word
- [x] Sets video context playback time to be equal to the currentTime value when it changes

Out of scope / not completed:
- [ ] Storybook showcase of this prop in action
- [ ] There is an ongoing issue with the quality of the media in DPE PreviewCanvas which is being addressed in DPE issue 40. 

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready for review. To test, you need to move the PreviewCanvas folder to your local DPE setup, and switch to `i85-double-click`. 

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->


<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
